### PR TITLE
Prevent panicking when no behaviors were configured

### DIFF
--- a/mediator/mediator.go
+++ b/mediator/mediator.go
@@ -43,7 +43,12 @@ func (mediator Mediator) Send(ctx context.Context, command cqrs_commands.IComman
 
 	handler := mediator.handlers[position]
 
+	if len(mediator.commandBehaviors) <= 0 {
+		return handler.HandleCommand(ctx, command)
+	}
+
 	mediator.commandBehaviors[len(mediator.commandBehaviors)-1].SetNextAction(handler.HandleCommand)
+
 	return mediator.commandBehaviors[0].HandleCommand(ctx, command)
 }
 
@@ -55,6 +60,10 @@ func (mediator Mediator) Request(ctx context.Context, query cqrs_queries.IQuery)
 	})
 
 	handler := mediator.queryHandlers[position]
+
+	if len(mediator.queryBehaviors) <= 0 {
+		return handler.HandleQuery(ctx, query)
+	}
 
 	mediator.queryBehaviors[len(mediator.queryBehaviors)-1].SetNextRequest(handler.HandleQuery)
 
@@ -93,15 +102,7 @@ func sortCommandBehaviors(behaviors []cqrs_behaviors.IBehavior) []cqrs_behaviors
 	return behaviors
 }
 
-func NewMediator(params MediatorParams) IMediator {
-	for index, behavior := range sortCommandBehaviors(params.CommandBehaviors) {
-		if index < len(params.CommandBehaviors)-1 {
-			behavior.SetNextAction(params.CommandBehaviors[index+1].HandleCommand)
-		} else {
-			behavior.SetNextAction(nil)
-		}
-	}
-
+func configureQueryBehaviors(params MediatorParams) {
 	for index, behavior := range params.QueryBehaviors {
 		if index < len(params.QueryBehaviors)-1 {
 			behavior.SetNextRequest(params.QueryBehaviors[index+1].HandleQuery)
@@ -109,6 +110,27 @@ func NewMediator(params MediatorParams) IMediator {
 			behavior.SetNextRequest(nil)
 		}
 	}
+}
+
+func configureCommandBehaviors(params MediatorParams) {
+	if len(params.CommandBehaviors) <= 0 {
+		return
+	}
+
+	for index, behavior := range sortCommandBehaviors(params.CommandBehaviors) {
+		if index < len(params.CommandBehaviors)-1 {
+			behavior.SetNextAction(params.CommandBehaviors[index+1].HandleCommand)
+		} else {
+			behavior.SetNextAction(nil)
+		}
+	}
+}
+
+func NewMediator(params MediatorParams) IMediator {
+	configureCommandBehaviors(params)
+
+	configureQueryBehaviors(params)
+
 	return Mediator{
 		commandBehaviors: params.CommandBehaviors,
 		queryBehaviors:   params.QueryBehaviors,

--- a/mediator/mediator.go
+++ b/mediator/mediator.go
@@ -2,6 +2,7 @@ package cqrs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -41,6 +42,12 @@ func (mediator Mediator) Send(ctx context.Context, command cqrs_commands.IComman
 		return strings.Contains(handlerName, commandName)
 	})
 
+	if position <= -1 {
+		message := fmt.Sprintf("command handler not found for command of type: %T", command)
+		err := errors.New(message)
+		panic(err)
+	}
+
 	handler := mediator.handlers[position]
 
 	if len(mediator.commandBehaviors) <= 0 {
@@ -58,6 +65,12 @@ func (mediator Mediator) Request(ctx context.Context, query cqrs_queries.IQuery)
 		commandName := fmt.Sprintf("%T", query)
 		return strings.Contains(handlerName, commandName)
 	})
+
+	if position <= -1 {
+		message := fmt.Sprintf("query handler not found for query of type: %T", query)
+		err := errors.New(message)
+		panic(err)
+	}
 
 	handler := mediator.queryHandlers[position]
 


### PR DESCRIPTION
When only using queries, the package panics because no command behaviors were registered into the DI container. 

- [x] configuring command behaviors only when the length is greater than zero.
- [x] preventing the `SetNextRequest` call when query behaviors length is less or equal to zero.
- [x] preventing the `SetNextAction` call when command behaviors length is less or equal to zero.
- [x] panic when the query handler index is less than or equal to -1.
- [x] panic when the command handler index is less than or equal to -1.


This PR will be released as version `1.0.3`