### PR TITLE
v1.4.0 - Fixing typos

### DIFF
--- a/events.go
+++ b/events.go
@@ -7,7 +7,7 @@ import (
 	"go.uber.org/multierr"
 )
 
-type IEvenHandler[TEvent any] interface {
+type IEventHandler[TEvent any] interface {
 	Handle(ctx context.Context, event TEvent) error
 }
 
@@ -25,7 +25,7 @@ func init() {
 	eventListener = make(chan *EventDelivery)
 }
 
-func RegisterEventSubcriber[TEvent any](handler IEvenHandler[TEvent]) error {
+func RegisterEventSubscriber[TEvent any](handler IEventHandler[TEvent]) error {
 	var event TEvent
 	eventType := reflect.TypeOf(event)
 	handlers, found := eventHandlers[eventType]
@@ -53,7 +53,7 @@ func PublishEvent[TEvent any](ctx context.Context, event TEvent) error {
 	var err error = nil
 
 	for _, h := range handlers {
-		handler, ok := h.(IEvenHandler[TEvent])
+		handler, ok := h.(IEventHandler[TEvent])
 
 		if ok {
 			handleErr := handler.Handle(ctx, event)

--- a/events.go
+++ b/events.go
@@ -2,6 +2,7 @@ package cqrs
 
 import (
 	"context"
+	"errors"
 	"reflect"
 
 	"go.uber.org/multierr"
@@ -38,6 +39,20 @@ func RegisterEventSubscriber[TEvent any](handler IEventHandler[TEvent]) error {
 	}
 
 	eventHandlers[eventType] = append(handlers, handler)
+
+	return nil
+}
+
+func RegisterEventSubscribers[TEvent any](handlers ...IEventHandler[TEvent]) error {
+	if len(handlers) <= 0 {
+		return errors.New("at least one handler must be provided")
+	}
+
+	for _, handler := range handlers {
+		if err := RegisterEventSubscriber(handler); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
# Version 1.4.0

## Enhancements

- [x] Adding support to register multiple event handlers

## Fixes

- [x] Fixing typo: `IEvenHandler`, it should be `IEventHandler`
- [x] Fixing typo: `RegisterEventSubcriber`, it should be `RegisterEventSubscriber`